### PR TITLE
Add fish completion

### DIFF
--- a/completions/fish/aws-vault.fish
+++ b/completions/fish/aws-vault.fish
@@ -1,0 +1,17 @@
+complete -c aws-vault -x -a '(__fish_aws_vault_completion)'
+
+function __fish_aws_vault_completion
+  if [ (count (commandline -opc)) = 1 ]
+    __fish_print_aws_vault_commands
+  else
+    __fish_print_aws_roles
+  end
+end
+
+function __fish_print_aws_vault_commands
+  aws-vault --help |awk '/^  [a-z]/ {print $1}'
+end
+
+function __fish_print_aws_roles
+  awk '/^\[profile/ {print $2}' ~/.aws/config |tr -d ']'
+end


### PR DESCRIPTION
## Context

Currently there is fish completion for bash and zsh.

## Change

Add fish completion, which uses `aws-vault --help` to complete the first
argument; and then looks at AWS config to complete subsequent ones.

I've been using this for a while successfully.